### PR TITLE
fix: replace Russian label in interview question 7

### DIFF
--- a/interviewQuestions/7/en.mdx
+++ b/interviewQuestions/7/en.mdx
@@ -6,7 +6,7 @@ meta:
 
 Use the `DISTINCT` keyword in the `SELECT` statement to return only unique records.
 
-Пример:
+Example:
 
 ```sql
 SELECT DISTINCT position


### PR DESCRIPTION
In `interviewQuestions/7/en.mdx`, the example heading was left in Russian (`Пример:`) instead of English.

This change replaces it with `Example:` to match the style used in other interview questions.

Fixes a localization oversight in the English version of question 7.