### PR TITLE
Уточнение материалов про UNION и даты

### DIFF
--- a/course/module-3/combining-queries/article.md
+++ b/course/module-3/combining-queries/article.md
@@ -23,7 +23,11 @@ SELECT table_fields FROM list_of_tables ... ;
 
 Table joining with the `UNION` operator is performed for tables that are not related in any way, but with a similar structure.
 
-In order for `UNION` to function correctly, it is essential that the resulting tables from each of the SQL queries contain the same number of columns with the same data types and in the same order.
+In order for `UNION` to function correctly, it is essential that the resulting tables from each of the SQL queries contain the same number of columns with compatible data types and in the same order.
+
+> Compatible data types are types for which the DBMS can choose a common result type.
+> For example, `INT` and `BIGINT` can be converted to a common numeric type. The types do not have to match exactly,
+> but if there is no common type, the query fails with an error.
 
 There are two other operators whose behavior is very similar to `UNION`:
 

--- a/course/module-5/work-with-datetime-data-type/article.md
+++ b/course/module-5/work-with-datetime-data-type/article.md
@@ -169,9 +169,9 @@ To do this, PostgreSQL uses the `EXTRACT` function:
 
 </PostgreSQLOnly>
 
-## The difference between DATETIME and TIMESTAMP
-
 <MySQLOnly>
+
+## MySQL: The difference between DATETIME and TIMESTAMP
 
 MySQL has very similar data types: `DATETIME` and `TIMESTAMP`. Both are aimed at storing the date and time.
 But they have a number of differences that determine which of these data types is best to use when.
@@ -184,6 +184,8 @@ But they have a number of differences that determine which of these data types i
 </MySQLOnly>
 
 <PostgreSQLOnly>
+
+## PostgreSQL: The difference between TIMESTAMP and TIMESTAMPTZ
 
 PostgreSQL has the main types for storing date and time: `TIMESTAMP` (without time zone) and `TIMESTAMPTZ` (with time zone).
 


### PR DESCRIPTION
Уточнены Markdown-материалы: для UNION заменено требование одинаковых типов на compatible data types, а разделы про DATETIME/TIMESTAMP получили явные DBMS-заголовки.

Issue: https://github.com/SQL-Academy/ru.sql-academy/issues/62

Связанный PR по UNION: https://github.com/SQL-Academy/ru.sql-academy/pull/65